### PR TITLE
parser: rely on Bison to type symbols

### DIFF
--- a/src/Parser.ypp
+++ b/src/Parser.ypp
@@ -1,4 +1,4 @@
-%skeleton "lalr1.cc"
+%skeleton "lalr1.cc"          // -*- c++ -*-
 %require "3.3"
 
 // Parser options
@@ -61,67 +61,144 @@
 %token tUKEYWORD
 %token tEXCLMETHOD
 
-// Keywords
-%token kALIAS
-%token kANY
-%token kATTRACCESSOR
-%token kATTRREADER
-%token kATTRWRITER
-%token kBOOL
-%token kBOT
-%token kCLASS
-%token kDEF
-%token kEND
-%token kEXTEND
-%token kEXTENSION
-%token kFALSE
-%token kIN
-%token kINCLUDE
-%token kINCOMPATIBLE
-%token kINSTANCE
-%token kINTERFACE
-%token kMODULE
-%token kNIL
-%token kOUT
-%token kPREPEND
-%token kPRIVATE
-%token kPUBLIC
-%token kSELF
-%token kSELFQ
-%token kSINGLETON
-%token kSUPER
-%token kTOP
-%token kTRUE
-%token kTYPE
-%token kUNCHECKED
-%token kUNTYPED
-%token kVOID
+%token <string>
+   // Keywords
+   kALIAS
+   kANY
+   kATTRACCESSOR
+   kATTRREADER
+   kATTRWRITER
+   kBOOL
+   kBOT
+   kCLASS
+   kDEF
+   kEND
+   kEXTEND
+   kEXTENSION
+   kFALSE
+   kIN
+   kINCLUDE
+   kINCOMPATIBLE
+   kINSTANCE
+   kINTERFACE
+   kMODULE
+   kNIL
+   kOUT
+   kPREPEND
+   kPRIVATE
+   kPUBLIC
+   kSELF
+   kSELFQ
+   kSINGLETON
+   kSUPER
+   kTOP
+   kTRUE
+   kTYPE
+   kUNCHECKED
+   kUNTYPED
+   kVOID
 
-// Punctuation
-%token kAMP
-%token kARROW
-%token kBAR
-%token kCOLON
-%token kCOLON2
-%token kCOMMA
-%token kDOT
-%token kEQ
-%token kEXCLAMATION
-%token kFATARROW
-%token kHAT
-%token kLBRACE
-%token kLBRACKET
-%token kLPAREN
-%token kLT
-%token kOPERATOR
-%token kQUESTION
-%token kRBRACE
-%token kRBRACKET
-%token kRPAREN
-%token kSTAR
-%token kSTAR2
+  // Punctuation
+  kAMP
+  kARROW
+  kBAR
+  kCOLON
+  kCOLON2
+  kCOMMA
+  kDOT
+  kEQ
+  kEXCLAMATION
+  kFATARROW
+  kHAT
+  kLBRACE
+  kLBRACKET
+  kLPAREN
+  kLT
+  kOPERATOR
+  kQUESTION
+  kRBRACE
+  kRBRACKET
+  kRPAREN
+  kSTAR
+  kSTAR2
 
-// Precedence
+%type <string>
+  tEXCLMETHOD
+  tGLOBALIDENT
+  tINTEGER
+  tINTERFACEIDENT
+  tIVAR
+  tLIDENT
+  tLKEYWORD
+  tNAMESPACE
+  tQUOTEDIDENT
+  tQUOTEDMETHOD
+  tSTRING
+  tSYMBOL
+  tUIDENT
+  tUKEYWORD
+
+  attr_var_opt
+  attributes
+  class_name
+  def_name
+  extension_name
+  identifier_keywords
+  interface_name
+  keyword
+  keyword_name
+  method_kind
+  method_name
+  method_name0
+  namespace
+  qualified_name
+  simple_name
+  super_class
+  type_param_check
+  type_param_variance
+  var_name_opt
+
+%type <node>
+  alias_member
+  attribute_member
+  block_opt
+  block_type
+  class_member
+  extend_member
+  include_member
+  method_member
+  method_type
+  module_self_type
+  module_type_param
+  optional_keyword
+  optional_positional
+  prepend_member
+  proc_type
+  record_field
+  record_type
+  required_keyword
+  required_positional
+  rest_keyword
+  rest_positional
+  simple_type
+  type
+
+%type <list>
+  class_members
+  keywords
+  method_types
+  module_type_params
+  module_type_params0
+  optional_positionals
+  params
+  params_opt
+  record_fields
+  rest_positionals
+  type_list
+  type_params
+  type_params0
+
+ // Precedence
 %nonassoc kQUESTION
 %left kAMP
 %left kBAR
@@ -152,28 +229,28 @@
 
   type_decl
     : kTYPE qualified_name kEQ type
-    { driver.file->decls.push_back(new TypeDecl(driver.loc(@1, @4), $2.string, static_cast<Type*>($4.node))); }
+    { driver.file->decls.push_back(new TypeDecl(driver.loc(@1, @4), $2, static_cast<Type*>($4))); }
 
   // Consts
 
   const_decl
     : class_name kCOLON type
-    { driver.file->decls.push_back(new Const(driver.loc(@1, @3), $1.string, static_cast<Type*>($3.node))); }
+    { driver.file->decls.push_back(new Const(driver.loc(@1, @3), $1, static_cast<Type*>($3))); }
     | namespace tUKEYWORD type
     {
-      $2.string->pop_back();
+      $2->pop_back();
       driver.file->decls.push_back(
         new Const(
           driver.loc(@1, @3),
-          new std::string(*$1.string + *$2.string),
-          static_cast<Type*>($3.node)));
+          new std::string(*$1 + *$2),
+          static_cast<Type*>($3)));
     }
 
   // Globals
 
   global_decl
     : tGLOBALIDENT kCOLON type
-    { driver.file->decls.push_back(new Global(driver.loc(@1, @3), $1.string, static_cast<Type*>($3.node))); }
+    { driver.file->decls.push_back(new Global(driver.loc(@1, @3), $1, static_cast<Type*>($3))); }
 
   // Extensions
 
@@ -181,11 +258,11 @@
     : kEXTENSION class_name module_type_params kLPAREN extension_name kRPAREN class_members kEND
     // TODO should be type params?
     {
-      Extension* decl = new Extension(driver.loc(@1, @8), $2.string, $5.string);
-      for (auto &node : $3.list->nodes) {
+      Extension* decl = new Extension(driver.loc(@1, @8), $2, $5);
+      for (auto &node : $3->nodes) {
         decl->typeParams.emplace_back(static_cast<TypeParam*>(node));
       }
-      for (auto &node : $7.list->nodes) {
+      for (auto &node : $7->nodes) {
         decl->members.emplace_back(static_cast<Member*>(node));
       }
       driver.file->decls.push_back(decl);
@@ -200,24 +277,24 @@
   module_decl
     : kMODULE class_name module_type_params module_self_type class_members kEND
     {
-      Module* decl = new Module(driver.loc(@1, @6), $2.string);
-      for (auto &node : $3.list->nodes) {
+      Module* decl = new Module(driver.loc(@1, @6), $2);
+      for (auto &node : $3->nodes) {
         decl->typeParams.emplace_back(static_cast<TypeParam*>(node));
       }
-      if ($4.node != NULL) {
-        decl->selfType = static_cast<Type*>($4.node);
+      if ($4 != NULL) {
+        decl->selfType = static_cast<Type*>($4);
       }
-      for (auto &node : $5.list->nodes) {
+      for (auto &node : $5->nodes) {
         decl->members.emplace_back(static_cast<Member*>(node));
       }
       driver.file->decls.push_back(decl);
     }
     | kMODULE namespace tUKEYWORD type class_members kEND
     {
-      $3.string->pop_back();
-      Module* decl = new Module(driver.loc(@1, @6), new std::string(*$2.string + *$3.string));
-      decl->selfType = static_cast<Type*>($4.node);
-      for (auto &node : $5.list->nodes) {
+      $3->pop_back();
+      Module* decl = new Module(driver.loc(@1, @6), new std::string(*$2 + *$3));
+      decl->selfType = static_cast<Type*>($4);
+      for (auto &node : $5->nodes) {
         decl->members.emplace_back(static_cast<Member*>(node));
       }
       driver.file->decls.push_back(decl);
@@ -225,7 +302,7 @@
 
   module_self_type
     : %empty
-    { $$.node = NULL; }
+    { $$ = NULL; }
     | kCOLON type
     { $$ = $2; }
 
@@ -234,11 +311,11 @@
   interface_decl
     : kINTERFACE interface_name module_type_params class_members kEND
     {
-      Interface* decl = new Interface(driver.loc(@1, @5), $2.string);
-      for (auto &node : $3.list->nodes) {
+      Interface* decl = new Interface(driver.loc(@1, @5), $2);
+      for (auto &node : $3->nodes) {
         decl->typeParams.emplace_back(static_cast<TypeParam*>(node));
       }
-      for (auto &node : $4.list->nodes) {
+      for (auto &node : $4->nodes) {
         decl->members.emplace_back(static_cast<Member*>(node));
       }
       driver.file->decls.push_back(decl);
@@ -246,18 +323,18 @@
 
   interface_name
     : namespace tINTERFACEIDENT
-    { $$.string = new std::string(*$1.string + *$2.string); }
+    { $$ = new std::string(*$1 + *$2); }
 
   // Classes
 
   class_decl
     : kCLASS class_name module_type_params super_class class_members kEND
     {
-      Class* decl = new Class(driver.loc(@1, @6), $2.string, $4.string);
-      for (auto &node : $3.list->nodes) {
+      Class* decl = new Class(driver.loc(@1, @6), $2, $4);
+      for (auto &node : $3->nodes) {
         decl->typeParams.emplace_back(static_cast<TypeParam*>(node));
       }
-      for (auto &node : $5.list->nodes) {
+      for (auto &node : $5->nodes) {
         decl->members.emplace_back(static_cast<Member*>(node));
       }
       driver.file->decls.push_back(decl);
@@ -265,52 +342,52 @@
 
   super_class
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | kLT class_name
-    { $$.string = $2.string; }
+    { $$ = $2; }
     | kLT class_name kLBRACKET type_list kRBRACKET
-    { $$.string = $2.string; }
+    { $$ = $2; }
 
   class_name
     : namespace tUIDENT
-    { $$.string = new std::string(*$1.string + *$2.string); }
+    { $$ = new std::string(*$1 + *$2); }
 
   // Generics
 
   module_type_params
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | kLBRACKET module_type_params0 kRBRACKET
-    { $$.list = $2.list; }
+    { $$ = $2; }
 
   module_type_params0
     : module_type_param
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | module_type_params0 kCOMMA module_type_param
-    { $$.list = driver.merge($1.list, $3.node); }
+    { $$ = driver.merge($1, $3); }
 
   module_type_param
     : type_param_check type_param_variance tUIDENT
-    { $$.node = new TypeParam(driver.loc(@1, @3), $3.string, $2.string, $1.string != NULL); }
+    { $$ = new TypeParam(driver.loc(@1, @3), $3, $2, $1 != NULL); }
 
   type_param_variance
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | kOUT
     | kIN
 
   type_param_check
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | kUNCHECKED
 
   // Class members
 
   class_members
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | class_members class_member
-    { $$.list = driver.merge($1.list, $2.node); }
+    { $$ = driver.merge($1, $2); }
 
   class_member
     : alias_member
@@ -319,71 +396,71 @@
     | extend_member
     | prepend_member
     | kPUBLIC
-    { $$.node = new Visibility(driver.loc(@1, @1), $1.string); }
+    { $$ = new Visibility(driver.loc(@1, @1), $1); }
     | kPRIVATE
-    { $$.node = new Visibility(driver.loc(@1, @1), $1.string); }
+    { $$ = new Visibility(driver.loc(@1, @1), $1); }
     | method_member
 
   alias_member
     : kALIAS method_name method_name
-    { $$.node = new Alias(driver.loc(@1, @3), $2.string, $3.string, false); }
+    { $$ = new Alias(driver.loc(@1, @3), $2, $3, false); }
     | kALIAS kSELF kDOT method_name kSELF kDOT method_name
-    { $$.node = new Alias(driver.loc(@1, @7), $4.string, $7.string, true); }
+    { $$ = new Alias(driver.loc(@1, @7), $4, $7, true); }
 
   attribute_member
     : kATTRREADER keyword type
-    { $$.node = new AttrReader(driver.loc(@1, @3), $2.string, NULL, static_cast<Type*>($3.node)); }
+    { $$ = new AttrReader(driver.loc(@1, @3), $2, NULL, static_cast<Type*>($3)); }
     | kATTRREADER method_name attr_var_opt kCOLON type
-    { $$.node = new AttrReader(driver.loc(@1, @5), $2.string, $3.string, static_cast<Type*>($5.node)); }
+    { $$ = new AttrReader(driver.loc(@1, @5), $2, $3, static_cast<Type*>($5)); }
     | kATTRWRITER keyword type
-    { $$.node = new AttrWriter(driver.loc(@1, @3), $2.string, NULL, static_cast<Type*>($3.node)); }
+    { $$ = new AttrWriter(driver.loc(@1, @3), $2, NULL, static_cast<Type*>($3)); }
     | kATTRWRITER method_name attr_var_opt kCOLON type
-    { $$.node = new AttrWriter(driver.loc(@1, @5), $2.string, $3.string, static_cast<Type*>($5.node)); }
+    { $$ = new AttrWriter(driver.loc(@1, @5), $2, $3, static_cast<Type*>($5)); }
     | kATTRACCESSOR keyword type
-    { $$.node = new AttrAccessor(driver.loc(@1, @3), $2.string, NULL, static_cast<Type*>($3.node)); }
+    { $$ = new AttrAccessor(driver.loc(@1, @3), $2, NULL, static_cast<Type*>($3)); }
     | kATTRACCESSOR method_name attr_var_opt kCOLON type
-    { $$.node = new AttrAccessor(driver.loc(@1, @5), $2.string, $3.string, static_cast<Type*>($5.node)); }
+    { $$ = new AttrAccessor(driver.loc(@1, @5), $2, $3, static_cast<Type*>($5)); }
 
   attr_var_opt
     : kLPAREN kRPAREN
-    { $$.string = new std::string(""); }
+    { $$ = new std::string(""); }
     | kLPAREN tIVAR kRPAREN
-    { $$.string = $2.string; }
+    { $$ = $2; }
 
   include_member
     : kINCLUDE qualified_name
-    { $$.node = new Include(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2.string)); }
+    { $$ = new Include(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2)); }
     | kINCLUDE qualified_name kLBRACKET type_list kRBRACKET
     {
-      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2.string);
-      for (auto &ptype : $4.list->nodes) {
+      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2);
+      for (auto &ptype : $4->nodes) {
         type->types.emplace_back(static_cast<Type*>(ptype));
       }
-      $$.node = new Include(driver.loc(@1, @5), type);
+      $$ = new Include(driver.loc(@1, @5), type);
     }
 
   extend_member
     : kEXTEND qualified_name
-    { $$.node = new Extend(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2.string)); }
+    { $$ = new Extend(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2)); }
     | kEXTEND qualified_name kLBRACKET type_list kRBRACKET
     {
-      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2.string);
-      for (auto &ptype : $4.list->nodes) {
+      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2);
+      for (auto &ptype : $4->nodes) {
         type->types.emplace_back(static_cast<Type*>(ptype));
       }
-      $$.node = new Extend(driver.loc(@1, @5), type);
+      $$ = new Extend(driver.loc(@1, @5), type);
     }
 
   prepend_member
     : kPREPEND qualified_name
-    { $$.node = new Prepend(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2.string)); }
+    { $$ = new Prepend(driver.loc(@1, @2), new TypeSimple(driver.loc(@2, @2), $2)); }
     | kPREPEND qualified_name kLBRACKET type_list kRBRACKET
     {
-      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2.string);
-      for (auto &ptype : $4.list->nodes) {
+      TypeGeneric* type = new TypeGeneric(driver.loc(@2, @5), $2);
+      for (auto &ptype : $4->nodes) {
         type->types.emplace_back(static_cast<Type*>(ptype));
       }
-      $$.node = new Prepend(driver.loc(@1, @5), type);
+      $$ = new Prepend(driver.loc(@1, @5), type);
     }
 
   // Methods
@@ -391,19 +468,19 @@
   method_member
     : attributes kDEF method_kind def_name method_types
     {
-      auto instance = $3.string == NULL || $3.string->compare("self?") == 0;
-      auto singleton = $3.string != NULL;
-      auto incompatible = $1.string != NULL;
-      Method* decl = new Method(driver.loc(@2, @5), $4.string, instance, singleton, incompatible);
-      for (auto &node : $5.list->nodes) {
+      auto instance = $3 == NULL || $3->compare("self?") == 0;
+      auto singleton = $3 != NULL;
+      auto incompatible = $1 != NULL;
+      Method* decl = new Method(driver.loc(@2, @5), $4, instance, singleton, incompatible);
+      for (auto &node : $5->nodes) {
         decl->types.emplace_back(static_cast<MethodType*>(node));
       }
-      $$.node = decl;
+      $$ = decl;
     }
 
   attributes
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | kINCOMPATIBLE
 
   def_name
@@ -412,18 +489,20 @@
 
   method_kind
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | kSELF kDOT
+    { $$ = $1; }
     | kSELFQ kDOT
+    { $$ = $1; }
 
   method_name
     : kOPERATOR
     | kAMP | kHAT | kSTAR | kLT | kEXCLAMATION | kSTAR2 | kBAR | kOUT | kIN
     | method_name0
     | method_name0 kQUESTION
-    { $$.string = new std::string(*$1.string + "?"); }
+    { $$ = new std::string(*$1 + "?"); }
     | method_name0 kEQ
-    { $$.string = new std::string(*$1.string + "="); }
+    { $$ = new std::string(*$1 + "="); }
     | tQUOTEDMETHOD
     | tQUOTEDIDENT
     | tEXCLMETHOD
@@ -441,137 +520,137 @@
 
   method_types
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | method_types kBAR method_type
-    { $$.list = driver.merge($1.list, $3.node); }
+    { $$ = driver.merge($1, $3); }
     | method_type
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
 
   method_type
     : type_params params_opt block_opt kARROW type
     {
       TypeProc* sig = new TypeProc(driver.loc(@1, @5));
-      for (auto &node : $2.list->nodes) {
+      for (auto &node : $2->nodes) {
         sig->params.emplace_back(static_cast<Param*>(node));
       }
-      sig->ret = static_cast<Type*>($5.node);
+      sig->ret = static_cast<Type*>($5);
 
       MethodType* type = new MethodType(driver.loc(@1, @5), sig);
-      for (auto &node : $1.list->nodes) {
+      for (auto &node : $1->nodes) {
         type->typeParams.emplace_back(static_cast<TypeParam*>(node));
       }
-      if ($3.node) {
-        type->block = static_cast<Block*>($3.node);
+      if ($3) {
+        type->block = static_cast<Block*>($3);
       }
-      $$.node = type;
+      $$ = type;
     }
 
   type_params
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | kLBRACKET type_params0 kRBRACKET
-    { $$.list = $2.list; }
+    { $$ = $2; }
 
   type_params0
     : tUIDENT
-    { $$.list = driver.list(new TypeParam(driver.loc(@1, @1), $1.string, NULL, false)); }
+    { $$ = driver.list(new TypeParam(driver.loc(@1, @1), $1, NULL, false)); }
     | type_params0 kCOMMA tUIDENT
-    { $$.list = driver.merge($1.list, new TypeParam(driver.loc(@3, @3), $3.string, NULL, false)); }
+    { $$ = driver.merge($1, new TypeParam(driver.loc(@3, @3), $3, NULL, false)); }
 
   params_opt
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | kLPAREN kRPAREN
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | kLPAREN kCOMMA kRPAREN
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | kLPAREN params kRPAREN
-    { $$.list = $2.list; }
+    { $$ = $2; }
 
   block_opt
     : %empty
-    { $$.node = NULL; }
+    { $$ = NULL; }
     | kLBRACE block_type kRBRACE
-    { $$.node = new Block(driver.loc(@1, @3), static_cast<TypeProc*>($2.node), false); }
+    { $$ = new Block(driver.loc(@1, @3), static_cast<TypeProc*>($2), false); }
     | kQUESTION kLBRACE block_type kRBRACE
-    { $$.node = new Block(driver.loc(@1, @3), static_cast<TypeProc*>($3.node), true); }
+    { $$ = new Block(driver.loc(@1, @3), static_cast<TypeProc*>($3), true); }
 
   block_type
     : kLPAREN kRPAREN kARROW type
-    { $$.node = new TypeProc(driver.loc(@1, @4), static_cast<Type*>($4.node)); }
+    { $$ = new TypeProc(driver.loc(@1, @4), static_cast<Type*>($4)); }
     | kLPAREN params kRPAREN kARROW type
     {
-      TypeProc* sig = new TypeProc(driver.loc(@1, @5), static_cast<Type*>($5.node));
-      for (auto &node : $2.list->nodes) {
+      TypeProc* sig = new TypeProc(driver.loc(@1, @5), static_cast<Type*>($5));
+      for (auto &node : $2->nodes) {
         sig->params.emplace_back(static_cast<Param*>(node));
       }
-      $$.node = sig;
+      $$ = sig;
     }
     | kARROW simple_type
-    { $$.node = new TypeProc(driver.loc(@1, @2), static_cast<Type*>($2.node)); }
+    { $$ = new TypeProc(driver.loc(@1, @2), static_cast<Type*>($2)); }
 
   params
     : required_positional kCOMMA params
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
     | required_positional
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | optional_positionals
 
   required_positional
     : type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @2), $2.string, static_cast<Type*>($1.node), false, false, false); }
+    { $$ = new Param(driver.loc(@1, @2), $2, static_cast<Type*>($1), false, false, false); }
 
   optional_positionals
     : optional_positional kCOMMA optional_positionals
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
     | optional_positional
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | rest_positionals
 
   optional_positional
     : kQUESTION type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @3), $3.string, static_cast<Type*>($2.node), false, true, false); }
+    { $$ = new Param(driver.loc(@1, @3), $3, static_cast<Type*>($2), false, true, false); }
 
   rest_positionals
     : rest_positional kCOMMA rest_positionals
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
     | rest_positional
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | keywords
 
   rest_positional
     : kSTAR type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @3), $3.string, static_cast<Type*>($2.node), false, false, true); }
+    { $$ = new Param(driver.loc(@1, @3), $3, static_cast<Type*>($2), false, false, true); }
 
   keywords
     : %empty
-    { $$.list = driver.list(); }
+    { $$ = driver.list(); }
     | required_keyword kCOMMA keywords
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
     | required_keyword
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | optional_keyword kCOMMA keywords
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
     | optional_keyword
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | rest_keyword
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
 
   required_keyword
     : keyword_name type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @2), $1.string, static_cast<Type*>($2.node), true, false, false); }
+    { $$ = new Param(driver.loc(@1, @2), $1, static_cast<Type*>($2), true, false, false); }
 
   optional_keyword
     : kQUESTION keyword_name type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @3), $2.string, static_cast<Type*>($3.node), true, false, false); }
+    { $$ = new Param(driver.loc(@1, @3), $2, static_cast<Type*>($3), true, false, false); }
 
   rest_keyword
     : kSTAR2 type var_name_opt
-    { $$.node = new Param(driver.loc(@1, @3), $3.string, static_cast<Type*>($2.node), false, false, true); }
+    { $$ = new Param(driver.loc(@1, @3), $3, static_cast<Type*>($2), false, false, true); }
 
   var_name_opt
     : %empty
-    { $$.string = NULL; }
+    { $$ = NULL; }
     | tLIDENT
     | tINTERFACEIDENT
     | tQUOTEDMETHOD
@@ -582,9 +661,9 @@
 
   keyword
     : tUKEYWORD
-    { $1.string->pop_back(); }
+    { $1->pop_back(); }
     | tLKEYWORD
-    { $1.string->pop_back(); }
+    { $1->pop_back(); }
 
   // Types
 
@@ -593,152 +672,152 @@
     | type kBAR type
     {
       std::vector<Type*> types;
-      if(TypeUnion* u = dynamic_cast<TypeUnion*>($1.node)) {
+      if(TypeUnion* u = dynamic_cast<TypeUnion*>($1)) {
         for (auto &type : u->types) {
           types.emplace_back(type);
         }
       } else {
-        types.emplace_back(static_cast<Type*>($1.node));
+        types.emplace_back(static_cast<Type*>($1));
       }
-      types.emplace_back(static_cast<Type*>($3.node));
-      $$.node = new TypeUnion(driver.loc(@1, @3), types);
+      types.emplace_back(static_cast<Type*>($3));
+      $$ = new TypeUnion(driver.loc(@1, @3), types);
     }
     | type kAMP type
     {
       std::vector<Type*> types;
-      if(TypeIntersection* u = dynamic_cast<TypeIntersection*>($1.node)) {
+      if(TypeIntersection* u = dynamic_cast<TypeIntersection*>($1)) {
         for (auto &type : u->types) {
           types.emplace_back(type);
         }
       } else {
-        types.emplace_back(static_cast<Type*>($1.node));
+        types.emplace_back(static_cast<Type*>($1));
       }
-      types.emplace_back(static_cast<Type*>($3.node));
-      $$.node = new TypeIntersection(driver.loc(@1, @3), types);
+      types.emplace_back(static_cast<Type*>($3));
+      $$ = new TypeIntersection(driver.loc(@1, @3), types);
     }
 
   simple_type
     : kBOOL
-    { $$.node = new TypeBool(driver.loc(@1, @1)); }
+    { $$ = new TypeBool(driver.loc(@1, @1)); }
     | kTRUE
-    { $$.node = new TypeTrue(driver.loc(@1, @1)); }
+    { $$ = new TypeTrue(driver.loc(@1, @1)); }
     | kFALSE
-    { $$.node = new TypeFalse(driver.loc(@1, @1)); }
+    { $$ = new TypeFalse(driver.loc(@1, @1)); }
     | kNIL
-    { $$.node = new TypeNil(driver.loc(@1, @1)); }
+    { $$ = new TypeNil(driver.loc(@1, @1)); }
     | kSELF
-    { $$.node = new TypeSelf(driver.loc(@1, @1)); }
+    { $$ = new TypeSelf(driver.loc(@1, @1)); }
     | kSELFQ
-    { $$.node = new TypeSelfQ(driver.loc(@1, @1)); }
+    { $$ = new TypeSelfQ(driver.loc(@1, @1)); }
     | kVOID
-    { $$.node = new TypeVoid(driver.loc(@1, @1)); }
+    { $$ = new TypeVoid(driver.loc(@1, @1)); }
     | kUNTYPED
-    { $$.node = new TypeUntyped(driver.loc(@1, @1)); }
+    { $$ = new TypeUntyped(driver.loc(@1, @1)); }
     | tSTRING
-    { $$.node = new TypeString(driver.loc(@1, @1), $1.string); }
+    { $$ = new TypeString(driver.loc(@1, @1), $1); }
     | kTOP
-    { $$.node = new TypeTop(driver.loc(@1, @1)); }
+    { $$ = new TypeTop(driver.loc(@1, @1)); }
     | kBOT
-    { $$.node = new TypeBot(driver.loc(@1, @1)); }
+    { $$ = new TypeBot(driver.loc(@1, @1)); }
     | kINSTANCE
-    { $$.node = new TypeInstance(driver.loc(@1, @1)); }
+    { $$ = new TypeInstance(driver.loc(@1, @1)); }
     | kANY
-    { $$.node = new TypeAny(driver.loc(@1, @1)); }
+    { $$ = new TypeAny(driver.loc(@1, @1)); }
     | kCLASS
-    { $$.node = new TypeClass(driver.loc(@1, @1)); }
+    { $$ = new TypeClass(driver.loc(@1, @1)); }
     | tINTEGER
-    { $$.node = new TypeInteger(driver.loc(@1, @1), $1.string); }
+    { $$ = new TypeInteger(driver.loc(@1, @1), $1); }
     | tSYMBOL
-    { $$.node = new TypeSymbol(driver.loc(@1, @1), $1.string); }
+    { $$ = new TypeSymbol(driver.loc(@1, @1), $1); }
     | qualified_name
-    { $$.node = new TypeSimple(driver.loc(@1, @1), $1.string); }
+    { $$ = new TypeSimple(driver.loc(@1, @1), $1); }
     | qualified_name kLBRACKET type_list kRBRACKET
     {
-      TypeGeneric* type = new TypeGeneric(driver.loc(@1, @4), $1.string);
-      for (auto &ptype : $3.list->nodes) {
+      TypeGeneric* type = new TypeGeneric(driver.loc(@1, @4), $1);
+      for (auto &ptype : $3->nodes) {
         type->types.emplace_back(static_cast<Type*>(ptype));
       }
-      $$.node = type;
+      $$ = type;
     }
     | kLBRACKET type_list kRBRACKET
     {
       TypeTuple* tuple = new TypeTuple(driver.loc(@1, @3));
-      for (auto &type : $2.list->nodes) {
+      for (auto &type : $2->nodes) {
         tuple->types.emplace_back(static_cast<Type*>(type));
       }
-      $$.node = tuple;
+      $$ = tuple;
     }
     | kLBRACKET kRBRACKET
-    { $$.node = new TypeTuple(driver.loc(@1, @1)); }
+    { $$ = new TypeTuple(driver.loc(@1, @1)); }
     | kLPAREN type kRPAREN
     { $$ = $2; }
     | kSINGLETON kLPAREN class_name kRPAREN
-    { $$.node = new TypeSingleton(driver.loc(@1, @4), $3.string); }
+    { $$ = new TypeSingleton(driver.loc(@1, @4), $3); }
     | simple_type kQUESTION
-    { $$.node = new TypeNilable(driver.loc(@1, @2), static_cast<Type*>($1.node)); }
+    { $$ = new TypeNilable(driver.loc(@1, @2), static_cast<Type*>($1)); }
     | kHAT proc_type
-    { $$.node = new Block(driver.loc(@1, @2), static_cast<TypeProc*>($2.node), false); }
+    { $$ = new Block(driver.loc(@1, @2), static_cast<TypeProc*>($2), false); }
     | record_type
 
   type_list
     : type
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | type_list kCOMMA type
-    { $$.list = driver.merge($1.list, $3.node); }
+    { $$ = driver.merge($1, $3); }
 
   proc_type
     : kLPAREN kRPAREN kARROW simple_type
-    { $$.node = new TypeProc(driver.loc(@1, @4), static_cast<Type*>($4.node)); }
+    { $$ = new TypeProc(driver.loc(@1, @4), static_cast<Type*>($4)); }
     | kLPAREN params kRPAREN kARROW simple_type
     {
-      TypeProc* sig = new TypeProc(driver.loc(@1, @5), static_cast<Type*>($5.node));
-      for (auto &node : $2.list->nodes) {
+      TypeProc* sig = new TypeProc(driver.loc(@1, @5), static_cast<Type*>($5));
+      for (auto &node : $2->nodes) {
         sig->params.emplace_back(static_cast<Param*>(node));
       }
-      $$.node = sig;
+      $$ = sig;
     }
     | kARROW simple_type
-    { $$.node = new TypeProc(driver.loc(@1, @2), static_cast<Type*>($2.node)); }
+    { $$ = new TypeProc(driver.loc(@1, @2), static_cast<Type*>($2)); }
 
   record_type
     : kLBRACE record_fields kRBRACE
     {
       Record* record = new Record(driver.loc(@1, @3));
-      for (auto &node : $2.list->nodes) {
+      for (auto &node : $2->nodes) {
         record->fields.emplace_back(static_cast<RecordField*>(node));
       }
-      $$.node = record;
+      $$ = record;
     }
 
   record_fields
     : record_field
-    { $$.list = driver.list($1.node); }
+    { $$ = driver.list($1); }
     | record_field kCOMMA record_fields
-    { $$.list = driver.merge($1.node, $3.list); }
+    { $$ = driver.merge($1, $3); }
 
   record_field
     : tSYMBOL kFATARROW type
-    { $$.node = new RecordField(driver.loc(@1, @3), $1.string, static_cast<Type*>($3.node)); }
+    { $$ = new RecordField(driver.loc(@1, @3), $1, static_cast<Type*>($3)); }
     | tSTRING kFATARROW type
-    { $$.node = new RecordField(driver.loc(@1, @3), $1.string, static_cast<Type*>($3.node)); }
+    { $$ = new RecordField(driver.loc(@1, @3), $1, static_cast<Type*>($3)); }
     | tINTEGER kFATARROW type
-    { $$.node = new RecordField(driver.loc(@1, @3), $1.string, static_cast<Type*>($3.node)); }
+    { $$ = new RecordField(driver.loc(@1, @3), $1, static_cast<Type*>($3)); }
     | keyword type
-    { $$.node = new RecordField(driver.loc(@1, @2), $1.string, static_cast<Type*>($2.node)); }
+    { $$ = new RecordField(driver.loc(@1, @2), $1, static_cast<Type*>($2)); }
 
   // Names
 
   namespace
     : %empty
-    { $$.string = new std::string(""); }
+    { $$ = new std::string(""); }
     | kCOLON2 tNAMESPACE
-    { $$.string = new std::string(*$1.string + *$2.string); }
+    { $$ = new std::string(*$1 + *$2); }
     | tNAMESPACE
     | kCOLON2
 
   qualified_name
     : namespace simple_name
-    { $$.string = new std::string(*$1.string + *$2.string); }
+    { $$ = new std::string(*$1 + *$2); }
 
   simple_name
     : tUIDENT


### PR DESCRIPTION
Hi!

I believe these changes will make the grammar easier to maintain.  If this commit accepted, I can provide more changes to simplify it further.  Unfortunately this big change cannot be broken into pieces: type-checking in Bison is all or nothing, I can't be incremental.

Currently "typing" is done by hand in the actions:

    namespace
      : %empty
      { $$.string = new std::string(""); }
      | kCOLON2 tNAMESPACE
      { $$.string = new std::string(*$1.string + *$2.string); }

This can be simplified using %type.

    namespace
      : %empty
      { $$ = new std::string(""); }
      | kCOLON2 tNAMESPACE
      { $$ = new std::string(*$1 + *$2); }

Besides, it will help migrating to Bison variants to use genuine
objects, instead of pointers to object:

    namespace
      : %empty
      { $$ = ""; }
      | kCOLON2 tNAMESPACE
      { $$ = $1 + $2; }